### PR TITLE
Added Apache Jira Link and fixed the security page linking inconsistency

### DIFF
--- a/src/main/webapp/docs/latest/mainpage.html
+++ b/src/main/webapp/docs/latest/mainpage.html
@@ -71,11 +71,17 @@
               <li class="dropdown">
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Community <span class="caret"></span></a>
                   <ul class="dropdown-menu">
-                      <li><a href="https://github.com/apache/incubator-carbondata/blob/master/docs/How-to-contribute-to-Apache-CarbonData.md"
-                             target="_blank">Contributing to CarbonData</a></li></li>
-                      <li><a href="https://cwiki.apache.org/confluence/display/CARBONDATA/Committers" target="_blank">Project Committers</a></li>
-                      <li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=66850609" target="_blank">CarbonData Meetups </a></li>
+                      <li>
+                          <a href="https://github.com/apache/incubator-carbondata/blob/master/docs/How-to-contribute-to-Apache-CarbonData.md"
+                             target="_blank">Contributing to CarbonData</a></li>
+                      <li>
+                          <a href="https://cwiki.apache.org/confluence/display/CARBONDATA/PPMC+and+Committers+member+list"
+                             target="_blank">Project PPMC and Committers</a></li>
+                      <li>
+                          <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=66850609"
+                             target="_blank">CarbonData Meetups</a></li>
                       <li><a href="../../security.html">Apache CarbonData Security</a></li>
+                      <li><a href="https://issues.apache.org/jira/browse/CARBONDATA" target="_blank">Apache Jira</a></li>
                   </ul>
                 </li>
                 <li class="dropdown">

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -87,7 +87,9 @@
                                    target="_blank">Project PPMC and Committers</a></li>
                             <li>
                                 <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=66850609"
-                                   target="_blank">CarbonData Meetups</a></li>                          
+                                   target="_blank">CarbonData Meetups</a></li>
+                            <li><a href="security.html">Apache CarbonData Security</a></li>
+                            <li><a href="https://issues.apache.org/jira/browse/CARBONDATA" target="_blank">Apache Jira</a></li>
                         </ul>
                     </li>
                     <li class="dropdown">
@@ -101,7 +103,6 @@
                                    target="_blank">License</a></li>
                             <li><a href="http://www.apache.org/foundation/sponsorship.html"
                                    target="_blank">Sponsorship</a></li>
-                            <li><a href="security.html">Apache CarbonData Security</a></li>
                             <li><a href="http://www.apache.org/foundation/thanks.html"
                                    target="_blank">Thanks</a></li>
                         </ul>

--- a/src/main/webapp/security.html
+++ b/src/main/webapp/security.html
@@ -63,11 +63,17 @@
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Community <span class="caret"></span></a>
                         <ul class="dropdown-menu">
-                            <li><a href="https://github.com/apache/incubator-carbondata/blob/master/docs/How-to-contribute-to-Apache-CarbonData.md"
-                                   target="_blank">Contributing to CarbonData</a></li></li>
-                            <li><a href="https://cwiki.apache.org/confluence/display/CARBONDATA/Committers" target="_blank">Project Committers</a></li>
-                            <li><a href="meetup.html">CarbonData Meetups </a></li>
-                            <li><a href="security.html">Apache CarbonData Security </a></li>
+                            <li>
+                                <a href="https://github.com/apache/incubator-carbondata/blob/master/docs/How-to-contribute-to-Apache-CarbonData.md"
+                                   target="_blank">Contributing to CarbonData</a></li>
+                            <li>
+                                <a href="https://cwiki.apache.org/confluence/display/CARBONDATA/PPMC+and+Committers+member+list"
+                                   target="_blank">Project PPMC and Committers</a></li>
+                            <li>
+                                <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=66850609"
+                                   target="_blank">CarbonData Meetups</a></li>
+                            <li><a href="security.html">Apache CarbonData Security</a></li>
+                            <li><a href="https://issues.apache.org/jira/browse/CARBONDATA" target="_blank">Apache Jira</a></li>
                         </ul>
                     </li>
                     <li class="dropdown">


### PR DESCRIPTION
The following changes have been made in this PR 
1. Added the Apache Jira Link in the Community Tab.
2. Fixed the In consitency in Security Link across the website pages.