### PR TITLE
[CARBONDATA-1336] add subscribe to issue list

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -409,8 +409,8 @@
                                                 target="_blank">Contributing to Apache CarbonData</a>.
                                         </li>
                                         <li> To report issue on <a
-                                                href="https://issues.apache.org/jira/browse/CARBONDATA"
-                                                target="_blank">Apache Jira</a>.
+                                                href="https://issues.apache.org/jira/browse/CARBONDATA" target="_blank">Apache Jira</a>. If you'd like, you can also subscribe to <a
+                                                href="https://mail-archives.apache.org/mod_mbox/carbondata-issues/" target="_blank">issues@carbondata.apache.org</a> to receive emails about new issues.
                                         </li>
                                     </ul>
                                     <h4 class="title">Mailing Lists


### PR DESCRIPTION
the page looks like:

![carbon-index-page](https://user-images.githubusercontent.com/10445758/28718288-d98a3c62-73d7-11e7-8fed-2f0ca04176e6.PNG)

After click the url，user will go to carbondata issue page [issues](https://mail-archives.apache.org/mod_mbox/carbondata-issues/), which contains subscribe/unsubscribe mailing lists.


I learn it from the Spark project as below:

![spark-issue-tracker-page](https://user-images.githubusercontent.com/10445758/28718385-3a1f4342-73d8-11e7-8161-fa691414a95d.PNG)

